### PR TITLE
wiki: add missing metadata

### DIFF
--- a/src/overlays/frappe/wiki.nix
+++ b/src/overlays/frappe/wiki.nix
@@ -12,6 +12,9 @@ buildPythonPackage rec {
     format
     ; # We can't extract anything other than format because pyproject.toml does not have the information
 
+  pname = "wiki";
+  version = "2.0.1";
+
   src = mkAssets appSources.wiki;
   inherit (appSources.wiki) passthru;
 


### PR DESCRIPTION
Previously the wiki was missing its pname and version as we couldn't extract them from the meta.

Unfortunately, some updates started using pname in a few places (e.g. mkSiteAssets.nix) which broke any sites using wiki. By manually adding the metadata we can sidestep this issue. It may be worth making an upstream commit to add pyproject.toml so we can properly extract the metadata, but that will have to be a followup sometime.