### PR TITLE
fix: oci testrig enabled apps

### DIFF
--- a/apps/sources/bench.nix
+++ b/apps/sources/bench.nix
@@ -1,16 +1,16 @@
 {
   pname = "bench";
-  version = "20250107.071544";
+  version = "20250128.054330";
   meta = {
-    url = "https://github.com/frappe/bench/commit/431cc783d19d1ea7bd637edc9a617f6c4e3ac319";
-    description = "Sources for bench (20250107.071544)";
+    url = "https://github.com/frappe/bench/commit/03f1af154b0c69745ead0214ca967a55436c9bf4";
+    description = "Sources for bench (20250128.054330)";
   };
   src = builtins.fetchTree {
     type = "github";
     owner = "frappe";
     repo = "bench";
-    narHash = "sha256-7s+/mweF+S3J52fIaUgz0rSXqpa2FCdDUe438DMP5dE=";
-    rev = "431cc783d19d1ea7bd637edc9a617f6c4e3ac319";
+    narHash = "sha256-rwlyCEfk469Wia/X45Hf2BE29cwEqXtc8LkPCj/4DAA=";
+    rev = "03f1af154b0c69745ead0214ca967a55436c9bf4";
   };
   passthru = builtins.fromJSON ''{}'';
 }

--- a/apps/sources/builder.nix
+++ b/apps/sources/builder.nix
@@ -9,6 +9,7 @@
     type = "git";
     url = "https://github.com/frappe/builder.git";
     submodules = true;
+    allRefs = true;
     narHash = "sha256-NrTnEUpkpHglkY6U1jdouh5VaC/OlK//Fkx2LCnlgpk=";
     rev = "8fa40c66de683aacc1abda1e2eaeada6fe4b9af5";
   };

--- a/apps/sources/builder.nix
+++ b/apps/sources/builder.nix
@@ -1,16 +1,16 @@
 {
   pname = "builder";
-  version = "v1.13.0";
+  version = "v1.13.1";
   meta = {
-    url = "https://github.com/frappe/builder/releases/tag/v1.13.0";
-    description = "Sources for builder (v1.13.0)";
+    url = "https://github.com/frappe/builder/releases/tag/v1.13.1";
+    description = "Sources for builder (v1.13.1)";
   };
   src = builtins.fetchTree {
     type = "git";
-    url = "git@github.com:frappe/builder.git";
+    url = "https://github.com/frappe/builder.git";
     submodules = true;
-    narHash = "sha256-pM23K/9rC9RmFf9VI5vDZsw4E1tAOJaCtnobh7bLOJI=";
-    rev = "8c6a098fc4aae572e5af9cff132617137fbc1f01";
+    narHash = "sha256-NrTnEUpkpHglkY6U1jdouh5VaC/OlK//Fkx2LCnlgpk=";
+    rev = "8fa40c66de683aacc1abda1e2eaeada6fe4b9af5";
   };
   passthru = builtins.fromJSON ''{}'';
 }

--- a/apps/sources/config.toml
+++ b/apps/sources/config.toml
@@ -48,8 +48,7 @@ exclude_regex = '.*-beta$'
 
 [gameplan]
 source = "github"
-branch = "patched"            # unmaintained? / no release yet
-github = "blaggacao/gameplan"
+github = "frappe/gameplan"
 use_commit = true
 submodules = true
 

--- a/apps/sources/crm.nix
+++ b/apps/sources/crm.nix
@@ -1,16 +1,16 @@
 {
   pname = "crm";
-  version = "v1.33.0";
+  version = "v1.34.6";
   meta = {
-    url = "https://github.com/frappe/crm/releases/tag/v1.33.0";
-    description = "Sources for crm (v1.33.0)";
+    url = "https://github.com/frappe/crm/releases/tag/v1.34.6";
+    description = "Sources for crm (v1.34.6)";
   };
   src = builtins.fetchTree {
     type = "git";
-    url = "git@github.com:frappe/crm.git";
+    url = "https://github.com/frappe/crm.git";
     submodules = true;
-    narHash = "sha256-q4u0X2CATuw/hkqQKA6Pir9LifFqXmHEIzY7+rHzJ+w=";
-    rev = "7e81a16f098d164ae0eeebfe5f1ef1784348b741";
+    narHash = "sha256-gmHzYOLinezUHHMsvZjSw6sosWTw/tylv2r8pECSl+g=";
+    rev = "b7d0cf73257bcb400aa56f0ed0d48bca638049b7";
   };
   passthru = builtins.fromJSON ''{}'';
 }

--- a/apps/sources/crm.nix
+++ b/apps/sources/crm.nix
@@ -9,6 +9,7 @@
     type = "git";
     url = "https://github.com/frappe/crm.git";
     submodules = true;
+    allRefs = true;
     narHash = "sha256-gmHzYOLinezUHHMsvZjSw6sosWTw/tylv2r8pECSl+g=";
     rev = "b7d0cf73257bcb400aa56f0ed0d48bca638049b7";
   };

--- a/apps/sources/erpnext.nix
+++ b/apps/sources/erpnext.nix
@@ -1,16 +1,16 @@
 {
   pname = "erpnext";
-  version = "v15.48.4";
+  version = "v15.49.3";
   meta = {
-    url = "https://github.com/frappe/erpnext/releases/tag/v15.48.4";
-    description = "Sources for erpnext (v15.48.4)";
+    url = "https://github.com/frappe/erpnext/releases/tag/v15.49.3";
+    description = "Sources for erpnext (v15.49.3)";
   };
   src = builtins.fetchTree {
     type = "github";
     owner = "frappe";
     repo = "erpnext";
-    narHash = "sha256-C/06TS25QAEiYDHG4sHGq+vZQWLp9PY57sSPylCNtl0=";
-    rev = "d1fee96f75efedd45024e4d6d581c9c3f687594a";
+    narHash = "sha256-rh88YPZGMtTpi2vDXfxgk+YRgbRA8IjB6oOj2fCLrbQ=";
+    rev = "de09da31bc56574dba539ffd45aabdd2904be7e6";
   };
   passthru = builtins.fromJSON ''{"since": "version-14", "upstream": "URL: https://github.com/frappe/erpnext\nPull: +refs/heads/develop:refs/remotes/upstream/develop\nPull: +refs/heads/version-15:refs/remotes/upstream/version-15\nPull: +refs/heads/version-15-hotfix:refs/remotes/upstream/version-15-hotfix\nPull: +refs/tags/v15.*:refs/remotes/upstream/tags/v15.*\n"}'';
 }

--- a/apps/sources/frappe.nix
+++ b/apps/sources/frappe.nix
@@ -1,16 +1,16 @@
 {
   pname = "frappe";
-  version = "v15.52.0";
+  version = "v15.54.1";
   meta = {
-    url = "https://github.com/frappe/frappe/releases/tag/v15.52.0";
-    description = "Sources for frappe (v15.52.0)";
+    url = "https://github.com/frappe/frappe/releases/tag/v15.54.1";
+    description = "Sources for frappe (v15.54.1)";
   };
   src = builtins.fetchTree {
     type = "github";
     owner = "frappe";
     repo = "frappe";
-    narHash = "sha256-NRagXPZMIPLipe2gus79SYvxDRQx9SMmaLnBvxKnXv0=";
-    rev = "3eda272bd61b1e73b74d30b1704d885a39c75d0c";
+    narHash = "sha256-Vn3/1EUht9T/MmVTyYz0UfSCKLyPJ1yJHjjC1Ws/mqk=";
+    rev = "4f2ee8b5ad36886fa03adc2ac88297f83f499785";
   };
   passthru = builtins.fromJSON ''{"clone": {"since": "version-14", "upstream": {"fetch": ["+refs/heads/develop:refs/remotes/upstream/develop", "+refs/heads/version-15:refs/remotes/upstream/version-15", "+refs/heads/version-15-hotfix:refs/remotes/upstream/version-15-hotfix", "+refs/tags/v15.*:refs/remotes/upstream/tags/v15.*"], "url": "https://github.com/frappe/frappe"}}}'';
 }

--- a/apps/sources/gameplan.nix
+++ b/apps/sources/gameplan.nix
@@ -7,7 +7,7 @@
   };
   src = builtins.fetchTree {
     type = "git";
-    url = "git@github.com:blaggacao/gameplan.git";
+    url = "https://github.com/blaggacao/gameplan.git";
     submodules = true;
     narHash = "sha256-HPzqeytml+oOreXAL1nDYDNFE+X9gTkPNey1pVtPcTE=";
     rev = "0e8a57023cffbde174b4668c19328bd8c74b4d32";

--- a/apps/sources/gameplan.nix
+++ b/apps/sources/gameplan.nix
@@ -7,7 +7,9 @@
   };
   src = builtins.fetchTree {
     type = "git";
-    url = "https://github.com/frappe/gameplan.git"; submodules = true;
+    url = "https://github.com/frappe/gameplan.git";
+    submodules = true;
+    allRefs = true;
     narHash = "sha256-boH6LJP4dNBcxzRN9ArVLaTOfkv9RLNkDn3iN3f5uyQ=";
     rev = "605e73d1db4908554f3e4bd60a96787d6c8dc081";
   };

--- a/apps/sources/gameplan.nix
+++ b/apps/sources/gameplan.nix
@@ -1,16 +1,15 @@
 {
   pname = "gameplan";
-  version = "20240723.013902";
+  version = "20241218.115224";
   meta = {
-    url = "https://github.com/blaggacao/gameplan/commit/0e8a57023cffbde174b4668c19328bd8c74b4d32";
-    description = "Sources for gameplan (20240723.013902)";
+    url = "https://github.com/frappe/gameplan/commit/605e73d1db4908554f3e4bd60a96787d6c8dc081";
+    description = "Sources for gameplan (20241218.115224)";
   };
   src = builtins.fetchTree {
     type = "git";
-    url = "https://github.com/blaggacao/gameplan.git";
-    submodules = true;
-    narHash = "sha256-HPzqeytml+oOreXAL1nDYDNFE+X9gTkPNey1pVtPcTE=";
-    rev = "0e8a57023cffbde174b4668c19328bd8c74b4d32";
+    url = "https://github.com/frappe/gameplan.git"; submodules = true;
+    narHash = "sha256-boH6LJP4dNBcxzRN9ArVLaTOfkv9RLNkDn3iN3f5uyQ=";
+    rev = "605e73d1db4908554f3e4bd60a96787d6c8dc081";
   };
   passthru = builtins.fromJSON ''{}'';
 }

--- a/apps/sources/hrms.nix
+++ b/apps/sources/hrms.nix
@@ -1,16 +1,16 @@
 {
   pname = "hrms";
-  version = "v15.38.0";
+  version = "v15.38.3";
   meta = {
-    url = "https://github.com/frappe/hrms/releases/tag/v15.38.0";
-    description = "Sources for hrms (v15.38.0)";
+    url = "https://github.com/frappe/hrms/releases/tag/v15.38.3";
+    description = "Sources for hrms (v15.38.3)";
   };
   src = builtins.fetchTree {
     type = "git";
-    url = "git@github.com:frappe/hrms.git";
+    url = "https://github.com/frappe/hrms.git";
     submodules = true;
-    narHash = "sha256-w4c5rv+o2oYUknG2dmAGE/bt3CaNcj57HbGzv5My73A=";
-    rev = "dd8541e9a609bb613c0022fd35665c9e84c34e48";
+    narHash = "sha256-rr5FRvROqPAIZUDjSVlM98qA4Mt8oleCm2eYoA5o6q4=";
+    rev = "fcf42f2e38af364ab98361d4baf5eef7ba50c775";
   };
   passthru = builtins.fromJSON ''{}'';
 }

--- a/apps/sources/hrms.nix
+++ b/apps/sources/hrms.nix
@@ -9,6 +9,7 @@
     type = "git";
     url = "https://github.com/frappe/hrms.git";
     submodules = true;
+    allRefs = true;
     narHash = "sha256-rr5FRvROqPAIZUDjSVlM98qA4Mt8oleCm2eYoA5o6q4=";
     rev = "fcf42f2e38af364ab98361d4baf5eef7ba50c775";
   };

--- a/apps/sources/insights.nix
+++ b/apps/sources/insights.nix
@@ -9,6 +9,7 @@
     type = "git";
     url = "git@github.com:frappe/insights.git";
     submodules = true;
+    allRefs = true;
     narHash = "sha256-ihSI55/2h31GqzhM6E4KvfI3kSJwhpHVOBGar+W8iGY=";
     rev = "9e8acedb5cdbb75a5f446911519ba777633eac5c";
   };

--- a/apps/sources/newver.json
+++ b/apps/sources/newver.json
@@ -7,16 +7,16 @@
       "url": "https://github.com/frappe/bench/commit/431cc783d19d1ea7bd637edc9a617f6c4e3ac319"
     },
     "builder": {
-      "version": "v1.13.0",
-      "gitref": "refs/tags/v1.13.0",
-      "revision": "8c6a098fc4aae572e5af9cff132617137fbc1f01",
-      "url": "https://github.com/frappe/builder/releases/tag/v1.13.0"
+      "version": "v1.13.1",
+      "gitref": "refs/tags/v1.13.1",
+      "revision": "8fa40c66de683aacc1abda1e2eaeada6fe4b9af5",
+      "url": "https://github.com/frappe/builder/releases/tag/v1.13.1"
     },
     "crm": {
-      "version": "v1.33.0",
-      "gitref": "refs/tags/v1.33.0",
-      "revision": "7e81a16f098d164ae0eeebfe5f1ef1784348b741",
-      "url": "https://github.com/frappe/crm/releases/tag/v1.33.0"
+      "version": "v1.34.6",
+      "gitref": "refs/tags/v1.34.6",
+      "revision": "b7d0cf73257bcb400aa56f0ed0d48bca638049b7",
+      "url": "https://github.com/frappe/crm/releases/tag/v1.34.6"
     },
     "drive": {
       "version": "v0.0.12",
@@ -47,10 +47,10 @@
       "url": "https://github.com/blaggacao/gameplan/commit/0e8a57023cffbde174b4668c19328bd8c74b4d32"
     },
     "hrms": {
-      "version": "v15.38.0",
-      "gitref": "refs/tags/v15.38.0",
-      "revision": "dd8541e9a609bb613c0022fd35665c9e84c34e48",
-      "url": "https://github.com/frappe/hrms/releases/tag/v15.38.0"
+      "version": "v15.38.3",
+      "gitref": "refs/tags/v15.38.3",
+      "revision": "fcf42f2e38af364ab98361d4baf5eef7ba50c775",
+      "url": "https://github.com/frappe/hrms/releases/tag/v15.38.3"
     },
     "insights": {
       "version": "v3.0.14",

--- a/apps/sources/newver.json
+++ b/apps/sources/newver.json
@@ -2,9 +2,9 @@
   "version": 2,
   "data": {
     "bench": {
-      "version": "20250107.071544",
-      "revision": "431cc783d19d1ea7bd637edc9a617f6c4e3ac319",
-      "url": "https://github.com/frappe/bench/commit/431cc783d19d1ea7bd637edc9a617f6c4e3ac319"
+      "version": "20250128.054330",
+      "revision": "03f1af154b0c69745ead0214ca967a55436c9bf4",
+      "url": "https://github.com/frappe/bench/commit/03f1af154b0c69745ead0214ca967a55436c9bf4"
     },
     "builder": {
       "version": "v1.13.1",
@@ -30,16 +30,16 @@
       "url": "https://github.com/frappe/ecommerce_integrations/commit/160b119a61555f1c5d62877e796e743a26e7ede8"
     },
     "erpnext": {
-      "version": "v15.48.4",
-      "gitref": "refs/tags/v15.48.4",
-      "revision": "d1fee96f75efedd45024e4d6d581c9c3f687594a",
-      "url": "https://github.com/frappe/erpnext/releases/tag/v15.48.4"
+      "version": "v15.49.3",
+      "gitref": "refs/tags/v15.49.3",
+      "revision": "de09da31bc56574dba539ffd45aabdd2904be7e6",
+      "url": "https://github.com/frappe/erpnext/releases/tag/v15.49.3"
     },
     "frappe": {
-      "version": "v15.52.0",
-      "gitref": "refs/tags/v15.52.0",
-      "revision": "3eda272bd61b1e73b74d30b1704d885a39c75d0c",
-      "url": "https://github.com/frappe/frappe/releases/tag/v15.52.0"
+      "version": "v15.54.1",
+      "gitref": "refs/tags/v15.54.1",
+      "revision": "4f2ee8b5ad36886fa03adc2ac88297f83f499785",
+      "url": "https://github.com/frappe/frappe/releases/tag/v15.54.1"
     },
     "gameplan": {
       "version": "20241218.115224",
@@ -76,14 +76,14 @@
       "url": "https://github.com/The-Commit-Company/Raven/releases/tag/v2.0.0"
     },
     "webshop": {
-      "version": "20241220.074108",
-      "revision": "18144ef826d407104deaa242dce1c046230ceec2",
-      "url": "https://github.com/frappe/webshop/commit/18144ef826d407104deaa242dce1c046230ceec2"
+      "version": "20250122.173714",
+      "revision": "22d0d5c930d0656672a2a75608d3a36d96ba375d",
+      "url": "https://github.com/frappe/webshop/commit/22d0d5c930d0656672a2a75608d3a36d96ba375d"
     },
     "wiki": {
-      "version": "20250121.061551",
-      "revision": "f4356adcd07c063fd5b9e98bccee625fedc64e00",
-      "url": "https://github.com/frappe/wiki/commit/f4356adcd07c063fd5b9e98bccee625fedc64e00"
+      "version": "20250128.065019",
+      "revision": "024fda864bdfab1248384fd4eca1e4710b4e24dc",
+      "url": "https://github.com/frappe/wiki/commit/024fda864bdfab1248384fd4eca1e4710b4e24dc"
     }
   }
 }

--- a/apps/sources/newver.json
+++ b/apps/sources/newver.json
@@ -42,9 +42,9 @@
       "url": "https://github.com/frappe/frappe/releases/tag/v15.52.0"
     },
     "gameplan": {
-      "version": "20240723.013902",
-      "revision": "0e8a57023cffbde174b4668c19328bd8c74b4d32",
-      "url": "https://github.com/blaggacao/gameplan/commit/0e8a57023cffbde174b4668c19328bd8c74b4d32"
+      "version": "20241218.115224",
+      "revision": "605e73d1db4908554f3e4bd60a96787d6c8dc081",
+      "url": "https://github.com/frappe/gameplan/commit/605e73d1db4908554f3e4bd60a96787d6c8dc081"
     },
     "hrms": {
       "version": "v15.38.3",

--- a/apps/sources/oldver.json
+++ b/apps/sources/oldver.json
@@ -42,9 +42,9 @@
       "url": "https://github.com/frappe/frappe/releases/tag/v15.52.0"
     },
     "gameplan": {
-      "version": "20240723.013902",
-      "revision": "0e8a57023cffbde174b4668c19328bd8c74b4d32",
-      "url": "https://github.com/blaggacao/gameplan/commit/0e8a57023cffbde174b4668c19328bd8c74b4d32"
+      "version": "20241218.115224",
+      "revision": "605e73d1db4908554f3e4bd60a96787d6c8dc081",
+      "url": "https://github.com/frappe/gameplan/commit/605e73d1db4908554f3e4bd60a96787d6c8dc081"
     },
     "hrms": {
       "version": "v15.38.3",

--- a/apps/sources/oldver.json
+++ b/apps/sources/oldver.json
@@ -2,9 +2,9 @@
   "version": 2,
   "data": {
     "bench": {
-      "version": "20250107.071544",
-      "revision": "431cc783d19d1ea7bd637edc9a617f6c4e3ac319",
-      "url": "https://github.com/frappe/bench/commit/431cc783d19d1ea7bd637edc9a617f6c4e3ac319"
+      "version": "20250128.054330",
+      "revision": "03f1af154b0c69745ead0214ca967a55436c9bf4",
+      "url": "https://github.com/frappe/bench/commit/03f1af154b0c69745ead0214ca967a55436c9bf4"
     },
     "builder": {
       "version": "v1.13.1",
@@ -30,16 +30,16 @@
       "url": "https://github.com/frappe/ecommerce_integrations/commit/160b119a61555f1c5d62877e796e743a26e7ede8"
     },
     "erpnext": {
-      "version": "v15.48.4",
-      "gitref": "refs/tags/v15.48.4",
-      "revision": "d1fee96f75efedd45024e4d6d581c9c3f687594a",
-      "url": "https://github.com/frappe/erpnext/releases/tag/v15.48.4"
+      "version": "v15.49.3",
+      "gitref": "refs/tags/v15.49.3",
+      "revision": "de09da31bc56574dba539ffd45aabdd2904be7e6",
+      "url": "https://github.com/frappe/erpnext/releases/tag/v15.49.3"
     },
     "frappe": {
-      "version": "v15.52.0",
-      "gitref": "refs/tags/v15.52.0",
-      "revision": "3eda272bd61b1e73b74d30b1704d885a39c75d0c",
-      "url": "https://github.com/frappe/frappe/releases/tag/v15.52.0"
+      "version": "v15.54.1",
+      "gitref": "refs/tags/v15.54.1",
+      "revision": "4f2ee8b5ad36886fa03adc2ac88297f83f499785",
+      "url": "https://github.com/frappe/frappe/releases/tag/v15.54.1"
     },
     "gameplan": {
       "version": "20241218.115224",
@@ -70,14 +70,14 @@
       "url": "https://github.com/The-Commit-Company/Raven/releases/tag/v2.0.0"
     },
     "webshop": {
-      "version": "20241220.074108",
-      "revision": "18144ef826d407104deaa242dce1c046230ceec2",
-      "url": "https://github.com/frappe/webshop/commit/18144ef826d407104deaa242dce1c046230ceec2"
+      "version": "20250122.173714",
+      "revision": "22d0d5c930d0656672a2a75608d3a36d96ba375d",
+      "url": "https://github.com/frappe/webshop/commit/22d0d5c930d0656672a2a75608d3a36d96ba375d"
     },
     "wiki": {
-      "version": "20250121.061551",
-      "revision": "f4356adcd07c063fd5b9e98bccee625fedc64e00",
-      "url": "https://github.com/frappe/wiki/commit/f4356adcd07c063fd5b9e98bccee625fedc64e00"
+      "version": "20250128.065019",
+      "revision": "024fda864bdfab1248384fd4eca1e4710b4e24dc",
+      "url": "https://github.com/frappe/wiki/commit/024fda864bdfab1248384fd4eca1e4710b4e24dc"
     }
   }
 }

--- a/apps/sources/oldver.json
+++ b/apps/sources/oldver.json
@@ -7,16 +7,16 @@
       "url": "https://github.com/frappe/bench/commit/431cc783d19d1ea7bd637edc9a617f6c4e3ac319"
     },
     "builder": {
-      "version": "v1.13.0",
-      "gitref": "refs/tags/v1.13.0",
-      "revision": "8c6a098fc4aae572e5af9cff132617137fbc1f01",
-      "url": "https://github.com/frappe/builder/releases/tag/v1.13.0"
+      "version": "v1.13.1",
+      "gitref": "refs/tags/v1.13.1",
+      "revision": "8fa40c66de683aacc1abda1e2eaeada6fe4b9af5",
+      "url": "https://github.com/frappe/builder/releases/tag/v1.13.1"
     },
     "crm": {
-      "version": "v1.33.0",
-      "gitref": "refs/tags/v1.33.0",
-      "revision": "7e81a16f098d164ae0eeebfe5f1ef1784348b741",
-      "url": "https://github.com/frappe/crm/releases/tag/v1.33.0"
+      "version": "v1.34.6",
+      "gitref": "refs/tags/v1.34.6",
+      "revision": "b7d0cf73257bcb400aa56f0ed0d48bca638049b7",
+      "url": "https://github.com/frappe/crm/releases/tag/v1.34.6"
     },
     "drive": {
       "version": "v0.0.12",
@@ -47,16 +47,10 @@
       "url": "https://github.com/blaggacao/gameplan/commit/0e8a57023cffbde174b4668c19328bd8c74b4d32"
     },
     "hrms": {
-      "version": "v15.38.0",
-      "gitref": "refs/tags/v15.38.0",
-      "revision": "dd8541e9a609bb613c0022fd35665c9e84c34e48",
-      "url": "https://github.com/frappe/hrms/releases/tag/v15.38.0"
-    },
-    "insights": {
-      "version": "v2.2.6",
-      "gitref": "refs/tags/v2.2.6",
-      "revision": "9e8acedb5cdbb75a5f446911519ba777633eac5c",
-      "url": "https://github.com/frappe/insights/releases/tag/v2.2.6"
+      "version": "v15.38.3",
+      "gitref": "refs/tags/v15.38.3",
+      "revision": "fcf42f2e38af364ab98361d4baf5eef7ba50c775",
+      "url": "https://github.com/frappe/hrms/releases/tag/v15.38.3"
     },
     "payments": {
       "version": "20241122.100234",

--- a/apps/sources/webshop.nix
+++ b/apps/sources/webshop.nix
@@ -1,16 +1,16 @@
 {
   pname = "webshop";
-  version = "20241220.074108";
+  version = "20250122.173714";
   meta = {
-    url = "https://github.com/frappe/webshop/commit/18144ef826d407104deaa242dce1c046230ceec2";
-    description = "Sources for webshop (20241220.074108)";
+    url = "https://github.com/frappe/webshop/commit/22d0d5c930d0656672a2a75608d3a36d96ba375d";
+    description = "Sources for webshop (20250122.173714)";
   };
   src = builtins.fetchTree {
     type = "github";
     owner = "frappe";
     repo = "webshop";
-    narHash = "sha256-zOw3sYcBKH0+Agw8QTJhDrro0nsd7ImC1mkQmA56QT4=";
-    rev = "18144ef826d407104deaa242dce1c046230ceec2";
+    narHash = "sha256-oJOmv5Kc7iesOsqfKv70Pg+VkxF9JSuHPQqs0rfn0Ng=";
+    rev = "22d0d5c930d0656672a2a75608d3a36d96ba375d";
   };
   passthru = builtins.fromJSON ''{}'';
 }

--- a/apps/sources/wiki.nix
+++ b/apps/sources/wiki.nix
@@ -1,16 +1,16 @@
 {
   pname = "wiki";
-  version = "20250121.061551";
+  version = "20250128.065019";
   meta = {
-    url = "https://github.com/frappe/wiki/commit/f4356adcd07c063fd5b9e98bccee625fedc64e00";
-    description = "Sources for wiki (20250121.061551)";
+    url = "https://github.com/frappe/wiki/commit/024fda864bdfab1248384fd4eca1e4710b4e24dc";
+    description = "Sources for wiki (20250128.065019)";
   };
   src = builtins.fetchTree {
     type = "github";
     owner = "frappe";
     repo = "wiki";
-    narHash = "sha256-iJPf3PQ1DgZqEC2/rqZ7Sjx7PgxVqZ7nFmbPdM7w1Ec=";
-    rev = "f4356adcd07c063fd5b9e98bccee625fedc64e00";
+    narHash = "sha256-c0BZWz3xvA2MxD97OHKERrQp5tyNeSN+2l/l+VyRyTU=";
+    rev = "024fda864bdfab1248384fd4eca1e4710b4e24dc";
   };
   passthru = builtins.fromJSON ''{}'';
 }

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
         (pkgs "pkgs")
 
         # App Sources
-        (anything "sources")
+        (self.nvchecker "sources")
 
         # Modules
         (anything "nixos")

--- a/src/oci-images.nix
+++ b/src/oci-images.nix
@@ -1,0 +1,14 @@
+let
+  inherit (inputs.nixpkgs) lib;
+  inherit (cell) pkgs oci;
+
+  evaled = lib.evalModules {
+    modules = [
+      {_module.args = {inherit pkgs;};}
+      oci.frappix
+      oci.testrig
+    ];
+  };
+in {
+  frappix-base = evaled.config.oci.frappix.image;
+}

--- a/src/oci.nix
+++ b/src/oci.nix
@@ -26,7 +26,7 @@
     }: {
       _file = ./oci.nix;
       imports = map (m: lib.modules.setDefaultModuleLocation m m) [
-        ./oci/testrig.nix
+        (import ./oci/testrig.nix inputs)
       ];
     };
   };

--- a/src/oci/testrig.nix
+++ b/src/oci/testrig.nix
@@ -10,6 +10,7 @@ inputs: {pkgs, ...}: {
         "crm" # brakes via https://github.com/frappe/crm/commit/a439433977321188266ff38cdef09642e4166080#commitcomment-148363342
         "drive" # waiting on https://github.com/blaggacao/frappix/pull/11
         "hrms" # brakes via https://github.com/frappe/hrms/issues/2342
+        "gameplan" # brakes via https://github.com/blaggacao/frappix/issues/18#issuecomment-2619829870
       ]);
     in
       map (name: pkgs.frappix.${name}) appList;

--- a/src/oci/testrig.nix
+++ b/src/oci/testrig.nix
@@ -11,6 +11,7 @@ inputs: {pkgs, ...}: {
         "drive" # waiting on https://github.com/blaggacao/frappix/pull/11
         "hrms" # brakes via https://github.com/frappe/hrms/issues/2342
         "gameplan" # brakes via https://github.com/blaggacao/frappix/issues/18#issuecomment-2619829870
+        "insights" # brakes via https://github.com/blaggacao/frappix/issues/18#issuecomment-2619860284
       ]);
     in
       map (name: pkgs.frappix.${name}) appList;

--- a/src/oci/testrig.nix
+++ b/src/oci/testrig.nix
@@ -9,7 +9,6 @@ inputs: {pkgs, ...}: {
         "builder" # brakes via https://github.com/frappe/builder/commit/cae39ff422812b52d3c1b25ae4756669add794d1#commitcomment-148362353
         "crm" # brakes via https://github.com/frappe/crm/commit/a439433977321188266ff38cdef09642e4166080#commitcomment-148363342
         "drive" # waiting on https://github.com/blaggacao/frappix/pull/11
-        "hrms" # brakes via https://github.com/frappe/hrms/issues/2342
         "gameplan" # brakes via https://github.com/blaggacao/frappix/issues/18#issuecomment-2619829870
         "insights" # brakes via https://github.com/blaggacao/frappix/issues/18#issuecomment-2619860284
       ]);

--- a/src/oci/testrig.nix
+++ b/src/oci/testrig.nix
@@ -1,17 +1,17 @@
-{pkgs, ...}: {
+inputs: {pkgs, ...}: {
   oci.frappix = {
     name = "ghcr.io/blaggacao/frappix-test-oci";
     debug = false;
-    apps = builtins.attrValues (builtins.removeAttrs pkgs.frappix [
-      "appSources"
-      "callPackage"
-      "newScope"
-      "overrideScope"
-      "overrideScope'"
-      "builder" # brakes via https://github.com/frappe/builder/commit/cae39ff422812b52d3c1b25ae4756669add794d1#commitcomment-148362353
-      "crm" # brakes via https://github.com/frappe/crm/commit/a439433977321188266ff38cdef09642e4166080#commitcomment-148363342
-      "drive" # waiting on https://github.com/blaggacao/frappix/pull/11
-      "hrms" # brakes via https://github.com/frappe/hrms/issues/2342
-    ]);
+    apps = let
+      appList = builtins.attrNames (builtins.removeAttrs inputs.cells.apps.sources [
+        "bench" # not an app
+        "frappe" # automatically added; don't add twice
+        "builder" # brakes via https://github.com/frappe/builder/commit/cae39ff422812b52d3c1b25ae4756669add794d1#commitcomment-148362353
+        "crm" # brakes via https://github.com/frappe/crm/commit/a439433977321188266ff38cdef09642e4166080#commitcomment-148363342
+        "drive" # waiting on https://github.com/blaggacao/frappix/pull/11
+        "hrms" # brakes via https://github.com/frappe/hrms/issues/2342
+      ]);
+    in
+      map (name: pkgs.frappix.${name}) appList;
   };
 }

--- a/src/overlays/frappe/ecommerce-integrations.nix
+++ b/src/overlays/frappe/ecommerce-integrations.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
   ];
 
   pythonRelaxDeps = [
-    # "shopify-python-api"
+    "shopifyapi"
     "boto3"
   ];
 

--- a/src/overlays/frappe/ecommerce-integrations.nix
+++ b/src/overlays/frappe/ecommerce-integrations.nix
@@ -26,12 +26,12 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = with python.pkgs; [
     shopify-python-api
-    boto
+    boto3
   ];
 
   pythonRelaxDeps = [
     # "shopify-python-api"
-    "boto"
+    "boto3"
   ];
 
   # would require frappe, but since frappe is almost certainly customized,

--- a/src/overlays/frappe/raven/default.nix
+++ b/src/overlays/frappe/raven/default.nix
@@ -26,6 +26,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = with python.pkgs; [
     linkpreview
+    openai
   ];
 
   # pythonRemoveDeps = [

--- a/src/overlays/tools/nvchecker.nix
+++ b/src/overlays/tools/nvchecker.nix
@@ -18,7 +18,7 @@
 }:
 buildPythonPackage rec {
   pname = "nvchecker";
-  version = "2.14dev-nix0";
+  version = "2.17dev-nix0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "blaggacao";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-p4dBoz/lJHcFKlx+SkLzYNurA9+HyMyQxSjC39lwVd8=";
+    hash = "sha256-kZtbKkwdEMP0tvWGEx6NFp5EGoP7N53RwMMWq1+OGJE=";
   };
 
   nativeBuildInputs = [

--- a/src/overlays/tools/nvchecker.nix
+++ b/src/overlays/tools/nvchecker.nix
@@ -18,7 +18,7 @@
 }:
 buildPythonPackage rec {
   pname = "nvchecker";
-  version = "2.17dev-nix0";
+  version = "2.17dev-nix1";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "blaggacao";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-kZtbKkwdEMP0tvWGEx6NFp5EGoP7N53RwMMWq1+OGJE=";
+    hash = "sha256-VlfRGOTkl2lWolHtNNj+i7n2JshR1sE5iqIEGvyfOfQ=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
This is intended to fix the CI failure:

```
  
         … while calling anonymous lambda
  
           at /nix/store/myizqfscgwf467msgjgnm197665ffml4-source/lib/types.nix:546:14:
  
            545|       merge = loc: defs:
            546|         map (x: x.value) (filter (x: x ? value) (concatLists (imap1 (n: def:
               |              ^
            547|           imap1 (m: def':
  
         error: A definition for option `oci.frappix.apps."[definition 1-entry 6]"' is not of type `package'. Definition values:
         - In `/nix/store/3gzq9h5zjng4zph25lrp4wvx4fahrkxw-incl/src/oci/testrig.nix': <function>
  Error: Process completed with exit code 1.  
```
