### PR TITLE
deployment-for-manual-testing: init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # nix
 result
 .nixos-test-history
+*.qcow2
 
 # nixago: ignore-linked-files
 /lefthook.yml

--- a/deployment-for-manual-testing/runnables.nix
+++ b/deployment-for-manual-testing/runnables.nix
@@ -1,0 +1,116 @@
+let
+  inherit (inputs) nixpkgs;
+  inherit (inputs.cells.src) pkgs nixos system;
+  inherit (nixpkgs) lib;
+  evalNixos = import (nixpkgs + /nixos/lib/eval-config.nix);
+
+  configuration = evalNixos {
+    system = null;
+
+    modules = [
+      {
+        nixpkgs = {
+          hostPlatform = {inherit system;};
+          inherit pkgs;
+        };
+      }
+
+      {system.stateVersion = "26.05";}
+
+      {
+        networking.hostName = "manual-testing-deployment";
+        virtualisation.vmVariant.virtualisation.qemu.networkingOptions = lib.mkForce [];
+      }
+
+      {
+        users = {
+          mutableUsers = false;
+          users.root.hashedPassword = "";
+        };
+        services.openssh = {
+          enable = true;
+          settings = {
+            PermitRootLogin = "yes";
+            PermitEmptyPasswords = "yes";
+          };
+        };
+        security.pam.services.sshd.allowNullPassword = true;
+      }
+
+      {
+        imports = ["${nixpkgs}/nixos/modules/profiles/headless.nix"];
+        services.journald.console = "/dev/ttyS0";
+      }
+
+      (nixosArgs: {
+        services.nginx.virtualHosts = lib.flip lib.mapAttrs nixosArgs.config.services.frappe.sites (_: _: {
+          enableACME = true;
+        });
+        security.acme.acceptTerms = true;
+        systemd = lib.mkMerge (lib.flip lib.mapAttrsToList nixosArgs.config.services.frappe.sites (
+          name: site: {
+            services."acme-order-renew-${name}".enable = false;
+            timers."acme-renew-${name}".enable = false;
+          }
+        ));
+      })
+
+      (nixosArgs: {
+        imports = [nixos.frappix];
+
+        services.frappe = {
+          enable = true;
+          project = "ManualTestDeployment";
+          gunicorn_workers = 1;
+          adminPassword = pkgs.writeText "admin-password.txt" "admin";
+          penv = lib.pipe nixosArgs.config.services.frappe.apps [
+            (lib.catAttrs "test-dependencies")
+            lib.flatten
+            (lib.concat nixosArgs.config.services.frappe.apps)
+            (extraLibs:
+              nixosArgs.config.services.frappe.package.pythonModule.buildEnv.override {
+                inherit extraLibs;
+              })
+            lib.mkForce
+          ];
+          commonSiteConfig = {
+            default_site = "frappix.localhost";
+            allow_tests = true;
+          };
+          sites."frappix.localhost" = {
+            domains = ["frappix.localhost"];
+            apps = ["frappe"];
+          };
+        };
+      })
+
+      {
+        virtualisation.vmVariant.virtualisation.qemu.options = [
+          "-display none"
+          "-serial file:/dev/stderr"
+          "-device virtio-balloon"
+        ];
+      }
+    ];
+  };
+in {
+  script =
+    (pkgs.writers.writeNuBin "deployment-for-manual-testing"
+      # nu
+      ''
+        def --wrapped main [ host_https_port: int host_ssh_port: int ...args ] {
+          let guest_https_port = ${toString configuration.config.services.nginx.defaultSSLListenPort}
+          let guest_ssh_port = ${toString (builtins.head configuration.config.services.openssh.ports)}
+
+          ${lib.getExe configuration.config.system.build.vm} ...[
+            -net "nic,netdev=user.0,model=virtio"
+            -netdev $"user,id=user.0,hostfwd=tcp::($host_https_port)-:($guest_https_port),hostfwd=tcp::($host_ssh_port)-:($guest_ssh_port)"
+            -smp ((sys cpu | length) - 1 | into string)
+            ...$args
+          ]
+        }
+      '')
+    // {
+      meta.description = "Headless VM for manual testing";
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
   } @ inputs:
     std.growOn {
       inherit inputs;
-      cellsFrom = std.incl ./. ["src" "local" "apps" "examples" "tests"];
+      cellsFrom = std.incl ./. ["src" "local" "apps" "examples" "tests" "deployment-for-manual-testing"];
       cellBlocks = with std.blockTypes; [
         (data "templates")
 
@@ -23,6 +23,7 @@
         (anything "nixos")
         (anything "shell")
         (nixostests "nixos-tests")
+        (runnables "runnables")
         (microvms "vms")
         (runnables "jobs" // {cli = false;}) # for downstream use
 


### PR DESCRIPTION
We originally began work not on this, but on the automated tests.
We still intend to resume that work in progress.
The intention is to have a passing and comprehensive test suite.
We have come to learn that a significant part of that is frappe's tests that can be run using

```
bench --verbose run-tests
```

Or, more practically, the `run-parallel-tests` variant.

#27

But while working on that, we noticed that the current manual testing story could be affected.
Which is runnning the automated test vms (nixos tests) in interactive mode.
So we wanted to decouple automated and manual testing.
We also wanted a somewhat more refined experience in manual testing.

This PR introduces a std runnable that wraps a nixos qemu vm.
It's a nushell script that takes a couple of arguments for port forwarding.
One is the https port and another is the ssh port.
Subsequent arguments are passed along to qemu.

At this point, trying to run bench tests in this vm will fail for probably more than one reason.
It is not our intention to produce a passing run in this PR.
It is our intention to follow up with work on automated testing, in which a passing run is definitely a goal.
And that can be followed by adjustments to allow a passing run in this manual test vm, as well.
We suppose that such a change would be achieved by sharing some relevant setup code between the automated test vms and the manual test vm.

Also, we didn't really try to use this vm other than logging in to the Administrator account using the web UI.
But we did run a single frappe test module in which most of the tests passed.

Please see the implementation for some more details.

---

Sponsored by https://www.wildnismanufaktur.bio/
